### PR TITLE
feat(FacultyController): Refactor API response handling

### DIFF
--- a/app/Http/Controllers/apicontroller/FacultyController.php
+++ b/app/Http/Controllers/apicontroller/FacultyController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\apicontroller;
 
+use App\Http\Controllers\ApiResponseCntroller;
 use App\Http\Controllers\Controller;
 use App\Models\CollegeFaculty;
 use Illuminate\Support\Facades\Validator;
@@ -12,61 +13,62 @@ class FacultyController extends Controller
     public function index()
     {
         $college_faculty = CollegeFaculty::all();
-        if ($college_faculty->count() > 0){
-            $data = [
-                'success'=> true,
-                'college_faculty'=> $college_faculty,
-                'statusCode' => 200,
-                'message'=> 'Records fetch successfully',
-            ];
-            return response()->json($data, 200);
+        if ($college_faculty->count() > 0) {
+         
+            return ApiResponseCntroller::response_success(data: $college_faculty, message: 'Records fetch successfully', status: 200);
+      
         } else {
-            $data = [
-                'success' => false,
-                'error' => [
-                    'message'=> 'No such records found',
-                ],
-                'statusCode' => 404,
-            ];
-            return response()->json($data, 404);
+   
+
+            return  ApiResponseCntroller::response_error(message: 'No such records found', status: 404);
+
         }
     }
 
     public function edit($id)
     {
         $college_faculty = CollegeFaculty::find($id);
-        
-        if ($college_faculty){
-            return response()->json([
-                'success'=> true,
-                'Data'=> $college_faculty,
-                'statusCode'=> 200,
-                'message'=> "Records fetch successfully",
-            ], 200);
+
+        if ($college_faculty) {
+
+
+            return ApiResponseCntroller::response_success(data: $college_faculty, message: 'Records fetch successfully', status: 200);
+
+            // return response()->json([
+            //     'success'=> true,
+            //     'Data'=> $college_faculty,
+            //     'statusCode'=> 200,
+            //     'message'=> "Records fetch successfully",
+            // ], 200);
         } else {
-            return response()->json([
-                'success' => false,
-                'error'=>[
-                  'message'=> "No such records found !",
-                ],
-                 'statusCode' => 404,
-            ], 404);
+
+            return ApiResponseCntroller::response_error(message: 'No such records founds', status: 404);
+            // return response()->json([
+            //     'success' => false,
+            //     'error'=>[
+            //       'message'=> "No such records found !",
+            //     ],
+            //      'statusCode' => 404,    
+            // ], 404);
+
         }
     }
 
     public function update(Request $request, int $id)
     {
-        $validator = Validator::make($request->all(),[
+        $validator = Validator::make($request->all(), [
             'college_id' => 'required',
             'department_id' => 'required',
-            'faculty_name'=> 'required|string|max:191',
+            'faculty_name' => 'required|string|max:191',
             'faculty_designation' => 'required|string|max:191'
         ]);
         if ($validator->fails()) {
-            return response()->json([
-                'success' => false,
-                'error'=> $validator->messages(),
-            ], 404);
+
+            return ApiResponseCntroller::response_error(message: 'Validation Error', errors: $validator->errors(), status: 404);
+            // return response()->json([
+            //     'success' => false,
+            //     'error' => $validator->messages(),
+            // ], 404);
         } else {
             $college_faculty = CollegeFaculty::find($id);
 
@@ -77,19 +79,21 @@ class FacultyController extends Controller
                     'faculty_name' => $request->faculty_name,
                     'faculty_designation' => $request->faculty_designation,
                 ]);
-                return response()->json([
-                     'success'=> true,
-                    'message'=> 'Data updated successfully !',
-                    'statusCode' => 202
-                ], 202);
+                return ApiResponseCntroller::response_success(data: $college_faculty, message: 'Data updated successfully !', status: 202);
+                // return response()->json([
+                //     'success' => true,
+                //     'message' => 'Data updated successfully !',
+                //     'statusCode' => 202
+                // ], 202);
             } else {
-                return response()->json([
-                     'success'=> false,
-                    'error'=> [
-                        'message'=> 'No such records founds',
-                    ],
-                    'statusCode' => 404,
-                ], 404);
+                return ApiResponseCntroller::response_error(message: 'No such records founds', status: 404);
+                // return response()->json([
+                //     'success' => false,
+                //     'error' => [
+                //         'message' => 'No such records founds',
+                //     ],
+                //     'statusCode' => 404,
+                // ], 404);
             }
         }
     }


### PR DESCRIPTION
This commit refactors the API response handling in the FacultyController
class. The changes include:

- Replacing the manual JSON response construction with the use of the
  ApiResponseController::response_success() and
  ApiResponseController::response_error() methods, which provide a
  consistent and reusable way to handle API responses.
- Removing the unnecessary comments and simplifying the code.
- Improving the error handling by returning more detailed validation
  errors.