### PR TITLE
feat: Disable spell check workflow

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,104 +1,104 @@
-name: Spell Check
+# name: Spell Check
 
-permissions:
-  pull-requests: write
-  contents: read
+# permissions:
+#   pull-requests: write
+#   contents: read
 
-on:
-  pull_request:
-  push:
-    branches: [dev, main]
+# on:
+#   pull_request:
+#   push:
+#     branches: [dev, main]
 
-jobs:
-  spell-check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    if: github.event_name == 'pull_request'
+# jobs:
+#   spell-check:
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 15
+#     if: github.event_name == 'pull_request'
 
-    steps:
-      - name: Check out the code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+#     steps:
+#       - name: Check out the code
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
+#       - name: Set up Node.js
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: 22
 
-      - name: Cache global npm packages
-        uses: actions/cache@v4
-        id: cache-cspell
-        with:
-          path: ~/.npm-global
-          key: ${{ runner.os }}-cspell-${{ hashFiles('**/cspell.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cspell-
+#       - name: Cache global npm packages
+#         uses: actions/cache@v4
+#         id: cache-cspell
+#         with:
+#           path: ~/.npm-global
+#           key: ${{ runner.os }}-cspell-${{ hashFiles('**/cspell.json') }}
+#           restore-keys: |
+#             ${{ runner.os }}-cspell-
 
-      - name: Configure npm global path
-        if: steps.cache-cspell.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.npm-global
-          npm config set prefix '~/.npm-global'
-          echo "~/.npm-global/bin" >> $GITHUB_PATH
+#       - name: Configure npm global path
+#         if: steps.cache-cspell.outputs.cache-hit != 'true'
+#         run: |
+#           mkdir -p ~/.npm-global
+#           npm config set prefix '~/.npm-global'
+#           echo "~/.npm-global/bin" >> $GITHUB_PATH
 
-      - name: Install cspell
-        if: steps.cache-cspell.outputs.cache-hit != 'true'
-        run: npm install -g cspell
+#       - name: Install cspell
+#         if: steps.cache-cspell.outputs.cache-hit != 'true'
+#         run: npm install -g cspell
 
-      - name: Get changed files
-        id: changed-files
-        run: |
-          echo "files=$(git diff --name-only --diff-filter=ACMRT origin/${{ github.base_ref }} HEAD | grep -E '\.(php|blade\.php|md|yml|yaml|json|js|jsx|ts|tsx|css|scss|vue)$' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+#       - name: Get changed files
+#         id: changed-files
+#         run: |
+#           echo "files=$(git diff --name-only --diff-filter=ACMRT origin/${{ github.base_ref }} HEAD | grep -E '\.(php|blade\.php|md|yml|yaml|json|js|jsx|ts|tsx|css|scss|vue)$' | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
-      - name: Run cspell on changed files
-        id: spell-check
-        run: |
-          if [ -z "${{ steps.changed-files.outputs.files }}" ]; then
-            echo "No files to check"
-            echo "spell_check_result=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          echo "Checking spelling in changed files..."
-          cspell --no-progress --config "cspell.json" ${{ steps.changed-files.outputs.files }} > cspell-output.txt || true
-          
-          if [ -s cspell-output.txt ]; then
-            {
-              echo "### 📝 Spell Check Results"
-              echo
-              current_file=""
-              while IFS= read -r line; do
-                file=$(echo "$line" | cut -d: -f1)
-                line_number=$(echo "$line" | cut -d: -f2)
-                error=$(echo "$line" | cut -d: -f3- | sed 's/^[[:space:]]*//')
-                word=$(echo "$error" | grep -oP 'Unknown word \(\K[^)]+')
-                
-                # Only print file name when it changes
-                if [ "$file" != "$current_file" ]; then
-                  echo "**$file**"
-                  current_file="$file"
-                fi
-                echo "- Line $line_number: \`$word\`"
-              done < cspell-output.txt
-            } > results.md
-            
-            echo 'spell_check_result<<SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
-            cat results.md >> $GITHUB_OUTPUT
-            echo 'SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
-          else
-            echo 'spell_check_result<<SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
-            echo "### 🎉 No spelling errors found!" >> $GITHUB_OUTPUT
-            echo 'SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
-          fi
+#       - name: Run cspell on changed files
+#         id: spell-check
+#         run: |
+#           if [ -z "${{ steps.changed-files.outputs.files }}" ]; then
+#             echo "No files to check"
+#             echo "spell_check_result=" >> $GITHUB_OUTPUT
+#             exit 0
+#           fi
 
-      - name: Post Spell Check Results
-        if: always()
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          message: |
-            ${{ steps.spell-check.outputs.spell_check_result }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-tag: spell-check-result
-          mode: upsert
-          create-if-not-exists: true
+#           echo "Checking spelling in changed files..."
+#           cspell --no-progress --config "cspell.json" ${{ steps.changed-files.outputs.files }} > cspell-output.txt || true
+
+#           if [ -s cspell-output.txt ]; then
+#             {
+#               echo "### 📝 Spell Check Results"
+#               echo
+#               current_file=""
+#               while IFS= read -r line; do
+#                 file=$(echo "$line" | cut -d: -f1)
+#                 line_number=$(echo "$line" | cut -d: -f2)
+#                 error=$(echo "$line" | cut -d: -f3- | sed 's/^[[:space:]]*//')
+#                 word=$(echo "$error" | grep -oP 'Unknown word \(\K[^)]+')
+
+#                 # Only print file name when it changes
+#                 if [ "$file" != "$current_file" ]; then
+#                   echo "**$file**"
+#                   current_file="$file"
+#                 fi
+#                 echo "- Line $line_number: \`$word\`"
+#               done < cspell-output.txt
+#             } > results.md
+
+#             echo 'spell_check_result<<SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
+#             cat results.md >> $GITHUB_OUTPUT
+#             echo 'SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
+#           else
+#             echo 'spell_check_result<<SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
+#             echo "### 🎉 No spelling errors found!" >> $GITHUB_OUTPUT
+#             echo 'SPELL_CHECK_EOF' >> $GITHUB_OUTPUT
+#           fi
+
+#       - name: Post Spell Check Results
+#         if: always()
+#         uses: thollander/actions-comment-pull-request@v3
+#         with:
+#           message: |
+#             ${{ steps.spell-check.outputs.spell_check_result }}
+#           github-token: ${{ secrets.GITHUB_TOKEN }}
+#           comment-tag: spell-check-result
+#           mode: upsert
+#           create-if-not-exists: true


### PR DESCRIPTION
The changes in this commit disable the spell check workflow by commenting out the entire workflow configuration. This is done to temporarily disable the spell check functionality, which may be causing issues or not providing value at the moment.