### PR TITLE
feat: Replace college_id with college_slug in routes and controllers

### DIFF
--- a/app/Http/Controllers/Frontend/FrontCollegeApiController.php
+++ b/app/Http/Controllers/Frontend/FrontCollegeApiController.php
@@ -13,33 +13,51 @@ use Illuminate\Http\Request;
 
 class FrontCollegeApiController extends Controller
 {
-    public function college_info_details($college_id)
+    public function college_info_details($college_slug)
     {
-        $college_details = College::where('id', $college_id)->first();
+        $college_details = College::where('slug', $college_slug)->first();
+        if (!$college_details) {
+            return ApiResponseCntroller::response_error(message: 'College not found', status: 404);
+        }
+
         return ApiResponseCntroller::response_success(data: $college_details, message: 'College details fetched successfully', status: 200);
     }
 
-    public function college_address_details($college_id)
+    public function college_address_details($college_slug)
     {
-        $college_address_details = CollegeContact::where('college_id', $college_id)->first();
+        $college_address_details = CollegeContact::where('college_slug', $college_slug)->first();
+        if (!$college_address_details) {
+            return ApiResponseCntroller::response_error(message: 'College address not found', status: 404);
+        }
         return ApiResponseCntroller::response_success(data: $college_address_details, message: 'College address details fetched successfully', status: 200);
     }
 
-    public function college_course_department_details($college_id)
+    public function college_course_department_details($college_slug)
     {
-        $college_course_department_details = CollegeCourseDepartment::with('college', 'course', 'department', 'fees')->where('college_id', $college_id)->first();
+        $college_course_department_details = CollegeCourseDepartment::with('college', 'course', 'department', 'fees')->where('college_slug', $college_slug)->first();
+
+        if (!$college_course_department_details) {
+            return ApiResponseCntroller::response_error(message: 'College course department not found', status: 404);
+        }
         return ApiResponseCntroller::response_success(data: $college_course_department_details, message: 'College course department details fetched successfully', status: 200);
     }
 
-    public function college_faculty_details($college_id)
+    public function college_faculty_details($college_slug)
     {
-        $college_faculty_details = CollegeFaculty::with('department')->where('college_id', $college_id)->get();
+        $college_faculty_details = CollegeFaculty::with('department')->where('college_slug', $college_slug)->get();
+
+        if (!$college_faculty_details) {
+            return ApiResponseCntroller::response_error(message: 'College faculty not found', status: 404);
+        }
         return ApiResponseCntroller::response_success(data: $college_faculty_details, message: 'College faculty details fetched successfully', status: 200);
     }
 
-    public function college_placement_details($college_id)
+    public function college_placement_details($college_slug)
     {
-        $college_placement_details = Placement::where('college_id', $college_id)->get();
+        $college_placement_details = Placement::where('college_slug', $college_slug)->get();
+        if (!$college_placement_details) {
+            return ApiResponseCntroller::response_error(message: 'College placement not found', status: 404);
+        }
         return ApiResponseCntroller::response_success(data: $college_placement_details, message: "College placement details");
     }
 }

--- a/cfm-bruno/College/list a college.bru
+++ b/cfm-bruno/College/list a college.bru
@@ -1,0 +1,11 @@
+meta {
+  name: list a college
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:8000/api/colleges/fghfg/info
+  body: none
+  auth: none
+}

--- a/routes/front_api.php
+++ b/routes/front_api.php
@@ -9,7 +9,7 @@ Route::post('colleges/submit', [FrontApiController::class, 'submit_application']
 Route::post('colleges/claim', [FrontApiController::class, 'claim_application']);
 Route::get('colleges/search/{key}', [SearchController::class, 'header_search']);
 Route::get('colleges/', [SearchController::class, 'college_filter_search']);
-Route::get('colleges/{college_id}/info', [FrontCollegeApiController::class, 'college_info_details']);
-Route::get('colleges/{college_id}/address', [FrontCollegeApiController::class, 'college_address_details']);
-Route::get('colleges/{college_id}/course-department', [FrontCollegeApiController::class, 'college_course_department_details']);
-Route::get('colleges/{college_id}/faculty', [FrontCollegeApiController::class, 'college_faculty_details']);
+Route::get('colleges/{college_slug}', [FrontCollegeApiController::class, 'college_info_details']);
+Route::get('colleges/{college_slug}/address', [FrontCollegeApiController::class, 'college_address_details']);
+Route::get('colleges/{college_slug}/course-department', [FrontCollegeApiController::class, 'college_course_department_details']);
+Route::get('colleges/{college_slug}/faculty', [FrontCollegeApiController::class, 'college_faculty_details']);


### PR DESCRIPTION
The changes made in this commit are focused on replacing the `college_id` parameter with `college_slug` in the routes and corresponding controller methods. This change is made to improve the user experience and make the URLs more intuitive and SEO-friendly.

The key changes are:

1. In the `routes/front_api.php` file, the routes for college-related information have been updated to use the `college_slug` parameter instead of `college_id`.
2. In the `app/Http/Controllers/Frontend/FrontCollegeApiController.php` file, the corresponding controller methods have been updated to accept the `college_slug` parameter and fetch the college details using the slug instead of the ID.
3. Additional error handling has been added to the controller methods to return appropriate error responses if the college is not found.

These changes will provide a better user experience by using more meaningful and SEO-friendly URLs, and also improve the overall robustness of the application.